### PR TITLE
Exports Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "main": "./dist/mz-react-round-slider.min.js",
   "exports": {
     "import": "./dist/mz-react-round-slider.esm.js",
-    "default": "./dist/mz-react-round-slider.min.js"
+    "default": "./dist/mz-react-round-slider.min.js",
+    "types": "./dist/index.d.ts"
   },
   "scripts": {
     "build:all": "npm run browser:build & npm run esm:build & npm run example:build",


### PR DESCRIPTION
This fixes the following error message:

```
Could not find a declaration file for module 'mz-react-round-slider'. 'node_modules/mz-react-round-slider/dist/mz-react-round-slider.esm.js' implicitly has an 'any' type.
  There are types at 'node_modules/mz-react-round-slider/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'mz-react-round-slider' library may need to update its package.json or typings.ts(7016)
```

Seems to be related to: https://github.com/microsoft/TypeScript/issues/52363